### PR TITLE
Fixed double release IBlob

### DIFF
--- a/udrJSON.pas
+++ b/udrJSON.pas
@@ -1283,7 +1283,7 @@ begin
       end;
     end;
     Blob.close(AStatus);
-	Blob := nil;
+    Blob := nil;
   finally
     if Assigned(Blob) then Blob.release;
     TransactionID.release;
@@ -1320,7 +1320,7 @@ begin
       Dec(sSize, Read);
     end;
     Blob.close(AStatus);
-	Blob := nil;
+    Blob := nil;
   finally
     if Assigned(Blob) then Blob.release;
     TransactionID.release;

--- a/udrJSON.pas
+++ b/udrJSON.pas
@@ -1283,6 +1283,7 @@ begin
       end;
     end;
     Blob.close(AStatus);
+	Blob := nil;
   finally
     if Assigned(Blob) then Blob.release;
     TransactionID.release;
@@ -1319,6 +1320,7 @@ begin
       Dec(sSize, Read);
     end;
     Blob.close(AStatus);
+	Blob := nil;
   finally
     if Assigned(Blob) then Blob.release;
     TransactionID.release;


### PR DESCRIPTION
Согласно документации в случае успешного выполнения IBlob.close освобождает интерфейс, поэтому выполнение

```
   Blob.close(AStatus);
  finally
    if Assigned(Blob) then Blob.release;
````

вызовет release у уже освобожденного объекта